### PR TITLE
Create package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+  <name>Help System</name>
+  <description>A help system for displaying FreeCAD documentation.</description>
+  <version>1.0.0-alpha</version>
+  <date>2022-03-11</date>
+  <maintainer email="yorik@uncreated.net">Yorik van Havre</maintainer>
+  <license file="LICENSE">LGPLv2.1</license>
+  <url type="repository" branch="main">https://github.com/yorikvanhavre/FreeCAD-Help</url>
+  <!-- No icon yet <icon></icon> -->
+
+  <content>
+    <workbench>
+      <classname>Help</classname>
+      <subdirectory>./</subdirectory>
+    </workbench>
+  </content>
+
+</package>


### PR DESCRIPTION
This creates a package.xml file for the Addon Manager -- I just left off the icon since there isn't one. It also refers to a non-existent LICENSE file, so one should be added. Finally, since this isn't really a workbench I think there will be an error on startup about being unable to locate an icon, because I didn't anticipate this sort of module's existence. I'll take care of cleaning that up in FreeCAD.